### PR TITLE
Accept non numeric errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Files and directories created by pub
 .dart_tool/
 .packages
+.vscode/
 # Remove the following pattern if you wish to check in your lock file
 pubspec.lock
 

--- a/lib/src/meteor_client.dart
+++ b/lib/src/meteor_client.dart
@@ -23,7 +23,9 @@ class MeteorError extends Error {
   MeteorError.parse(Map<String, dynamic> object) {
     try {
       details = object['details']?.toString();
-      error = error = int.tryParse(object['error']) ?? object['error'];
+      error = object['error'] is String
+          ? int.tryParse(object['error']) ?? object['error']
+          : object['error'];
       errorType = object['errorType']?.toString();
       isClientSafe = object['isClientSafe'] == true;
       message = object['message']?.toString();

--- a/lib/src/meteor_client.dart
+++ b/lib/src/meteor_client.dart
@@ -13,7 +13,7 @@ class MeteorClientLoginResult {
 
 class MeteorError extends Error {
   String details;
-  int error;
+  dynamic error;
   String errorType;
   bool isClientSafe;
   String message;
@@ -23,9 +23,7 @@ class MeteorError extends Error {
   MeteorError.parse(Map<String, dynamic> object) {
     try {
       details = object['details']?.toString();
-      error = object['error'] is String
-          ? int.parse(object['error'])
-          : object['error'];
+      error = error = int.tryParse(object['error']) ?? object['error'];
       errorType = object['errorType']?.toString();
       isClientSafe = object['isClientSafe'] == true;
       message = object['message']?.toString();


### PR DESCRIPTION
This is a tiny patch to allow parsing of errors that contain a non-numerical `string` as the `error` field. Some of our endpoints have this behavior. 

Cheers!