### PR TITLE
Improve: get the stream of Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,16 +153,10 @@ meteor.call('helloMethod', []).then((result) {
 You can found an example project inside [/example][example].
 
 ## Collections & Subscriptions
-Prepare your collections before use. You can use `prepareCollection` method in `initState()` or in your `main` function.
+Prepare your collections before use. You can use `getOrPrepareCollection` method in `StreamBuilder` or whenevr you want to get the `Stream`. Through the return `Stream` reference you can listen the updates of the collection.
 
 ```dart
-meteor.prepareCollection('your_collections');
-```
-
-Then access it with
-
-```dart
-meteor.collections['test']
+meteor.getOrPrepareCollection('your_collections');
 ```
 
 which return rxdart's Observable that you can use it as a simple Stream. To make collections available in Flutter app you might make a subscription to your server with:
@@ -181,8 +175,7 @@ class _YourWidgetState extends State<YourWidget> {
   @override
   void initState() {
     super.initState();
-    meteor.prepareCollection('your_collection');
-    _subscriptionHandler = meteor.subscribe('your_pub', []);
+    _subscriptionHandler = meteor.subscribe('your_pub', ['param_1', 'param_2']);
   }
 
   @override
@@ -194,7 +187,7 @@ class _YourWidgetState extends State<YourWidget> {
   @override
   Widget build(BuildContext context) {
     return StreamBuilder(
-      stream: meteor.collections['your_collection'],
+      stream: meteor.getOrPrepareCollection('your_collection'),
       builder:
           (context, AsyncSnapshot<Map<String, dynamic>> snapshot) {
         int docCount = 0;

--- a/lib/src/meteor_client.dart
+++ b/lib/src/meteor_client.dart
@@ -73,7 +73,7 @@ class MeteorClient {
   /// Meteor.collections
   Map<String, Map<String, dynamic>> _collections = {};
   Map<String, BehaviorSubject<Map<String, dynamic>>> _collectionsSubject = {};
-  Map<String, Stream<Map<String, dynamic>>> collections = {};
+  Map<String, Stream<Map<String, dynamic>>> _collectionStreams = {};
 
   MeteorClient.connect({String url}) {
     url = url.replaceFirst(RegExp(r'^http'), 'ws');
@@ -98,7 +98,7 @@ class MeteorClient {
     _userIdStream = _userIdSubject.stream;
     _userStream = _userSubject.stream;
 
-    prepareCollection('users');
+    getOrPrepareCollection('users');
 
     connection.dataStreamController.stream.listen((data) {
       String collectionName = data['collection'];
@@ -112,7 +112,7 @@ class MeteorClient {
         _collections[collectionName] = {};
         _collectionsSubject[collectionName] =
             BehaviorSubject<Map<String, dynamic>>();
-        collections[collectionName] =
+        _collectionStreams[collectionName] =
             _collectionsSubject[collectionName].stream;
       }
 
@@ -173,15 +173,15 @@ class MeteorClient {
     });
   }
 
-  /// To make sure that the stream is not null when accessing them through `collections`
-  /// If you not call prepareCollection, the stream will be null until it got data from ddp `collection` message.
-  void prepareCollection(String collectionName) {
+  /// Get [Stream] of `collection` on given `collectionName`. If the [Stream] has not yet be prepared then intiating it
+  Stream<Map<String, dynamic>> getOrPrepareCollection(String collectionName) {
     if (_collections[collectionName] == null) {
       _collections[collectionName] = {};
       var subject = _collectionsSubject[collectionName] =
           BehaviorSubject<Map<String, dynamic>>();
-      collections[collectionName] = subject.stream;
+      _collectionStreams[collectionName] = subject.stream;
     }
+    return _collectionStreams[collectionName];
   }
 
   // ===========================================================
@@ -324,7 +324,7 @@ class MeteorClient {
   }
 
   /// A Map containing user documents.
-  Stream<Map<String, dynamic>> get users => collections['users'];
+  Stream<Map<String, dynamic>> get users => _collectionStreams['users'];
 
   /// True if a login method (such as Meteor.loginWithPassword, Meteor.loginWithFacebook, or Accounts.createUser) is currently in progress.
   /// A reactive data source.


### PR DESCRIPTION
- No need to firstly call `prepareCollection` and then get the `Stream` from accessing member field.
- Changed original `collections` to private and renamed it as `_collectionStreams`