### PR TITLE
fix: set default collection data 

### DIFF
--- a/lib/src/meteor_client.dart
+++ b/lib/src/meteor_client.dart
@@ -202,6 +202,7 @@ class MeteorClient {
       _collections[collectionName] = {};
       var subject = _collectionsSubject[collectionName] =
           BehaviorSubject<Map<String, dynamic>>();
+      subject.add({});
       _collectionsStreams[collectionName] = subject.stream;
     }
   }


### PR DESCRIPTION
This changes are related to the issue #58.

This issue happen when the collection is empty. For some reason the subscription is set to ready but the server doesn't emit a `added` event or anything like that because there is nothing to add. When using StreamBuilder, the snapshot keeps waiting on the data.

I fixed just by adding an empty map when preparing the collection for the first time. 

Feel free to give me some feedback or suggetion to improve the solution.