### PR TITLE
Web support

### DIFF
--- a/lib/src/ddp_client.dart
+++ b/lib/src/ddp_client.dart
@@ -232,7 +232,7 @@ class DdpClient {
       _connectionStatus.reason = null;
       _statusStreamController.sink.add(_connectionStatus);
       try {
-        _socket = WebSocketChannel.connect(Uri.parse(url));//, headers: { 'User-Agent': userAgent });
+        _socket = WebSocketChannel.connect(Uri.parse(url));
         _connectionStatus.retryCount = 0;
         _connectionStatus.retryTime = Duration(seconds: 1);
         _socket!.stream.listen(

--- a/lib/src/ddp_client.dart
+++ b/lib/src/ddp_client.dart
@@ -1,5 +1,5 @@
 import 'dart:convert';
-import 'dart:io';
+import 'dart:io' if (dart.library.html) 'dart:html';
 import 'dart:async';
 import 'dart:math';
 

--- a/lib/src/ddp_client.dart
+++ b/lib/src/ddp_client.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
-import 'dart:io' if (dart.library.html) 'dart:html';
+import 'package:web_socket_channel/web_socket_channel.dart';
+import 'dart:io';
 import 'dart:async';
 import 'dart:math';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   crypto: ^3.0.1
   rxdart: ^0.27.0
+  web_socket_channel: ^2.3.0
 
 dev_dependencies:
   pedantic: ^1.11.0


### PR DESCRIPTION
Hi,
I really needed web support for one of my projects, so I worked on the implementation.

As the other PR regarding this topic hasn't been updated for a year, I started over, using the last version of everything instead of starting from there.

Here are a few explanations about my choices : 
- I first wrote a custom wrapper to avoid introducing a new dependency. But web_socket_channel is pretty light and very well maintained so I thought it made more sense to reuse their work
- I didn't use the userAgent as we cannot use it with dart:html and it works perfectly fine without it. Seems simpler and more consistent that way. If you think it's important to keep it for dart:io, I can write a wrapper similar to the one used in web_socket_channel but able to handle the header parameters (web_socket_channel chose not to handle it in their cross-platform class and conditional import requires a common class with an implementation per platform to compile, that was the issue with the other PR on that topic)

Let me know if you want me to change something